### PR TITLE
feat: add UI + CLI mode modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +604,7 @@ dependencies = [
  "async-trait",
  "dialoguer",
  "dotenv",
+ "indicatif",
  "reqwest",
  "serde_json",
  "tokio",
@@ -638,6 +652,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -744,6 +764,12 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "proc-macro2"
@@ -1303,6 +1329,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ dialoguer = "0.11.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1.0.138"
 dotenv = "0.15.0"
+indicatif = "0.17.11"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
 
-mod providers;
+pub mod providers;
+pub mod ui;
+pub mod modes;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -17,6 +19,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let provider = &providers[selected_idx];
 
     println!("Selected provider: {}", provider.name());
+
+    let mode = ui::select_mode().await?;
+
+    println!("Selected mode: {}", mode.description());
 
     Ok(())
 }

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -1,0 +1,16 @@
+#[derive(Debug)]
+pub enum Mode {
+    CommitMessage,
+    FileAnalysis,
+    ContributorAnalysis,
+}
+
+impl Mode {
+    pub fn description(&self) -> &'static str {
+        match self {
+            Mode::CommitMessage => "Generate commit message",
+            Mode::FileAnalysis => "Analyze file changes",
+            Mode::ContributorAnalysis => "Analyze contributors",
+        }
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,41 @@
+use std::error::Error;
+use dialoguer::{theme::ColorfulTheme, Select};
+use indicatif::{ProgressBar, ProgressStyle};
+
+use crate::modes::Mode;
+
+pub fn create_spinner(message: &str) -> Result<ProgressBar, Box<dyn Error>> {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_style(
+        ProgressStyle::default_spinner()
+            .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈")
+            .template("{spinner} {msg}...")?
+    );
+    spinner.enable_steady_tick(std::time::Duration::from_millis(100));
+    spinner.set_message(format!("{}...", message));
+    Ok(spinner)
+}
+
+pub fn show_selection_menu<T: AsRef<str> + ToString>(prompt: &str, items: &[T], default: usize) -> Result<usize, Box<dyn Error>> {
+    Ok(Select::with_theme(&ColorfulTheme::default())
+        .with_prompt(prompt)
+        .items(items)
+        .default(default)
+        .interact()?)
+}
+
+pub async fn select_mode() -> Result<Mode, Box<dyn Error>> {
+    let modes = [
+        Mode::CommitMessage.description(),
+        Mode::FileAnalysis.description(),
+        Mode::ContributorAnalysis.description(),
+    ];
+    
+    let selection = show_selection_menu("What would you like to do?", &modes, 0)?;
+    
+    Ok(match selection {
+        0 => Mode::CommitMessage,
+        1 => Mode::FileAnalysis,
+        _ => Mode::ContributorAnalysis,
+    })
+}


### PR DESCRIPTION
Build boilerplate CLI modes for writing a commit description, analyzing file changes, and analyzing contributor patterns.

Add a UI module for accepting select inputs from the user.

<img width="206" alt="image" src="https://github.com/user-attachments/assets/f3385135-0877-42d1-ab43-3858e2b8a735" />